### PR TITLE
Handle UPP Annotations Error Status Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Draft content API
+# Draft Annotations API
 
 [![Circle CI](https://circleci.com/gh/Financial-Times/draft-annotations-api/tree/master.png?style=shield)](https://circleci.com/gh/Financial-Times/draft-annotations-api/tree/master)[![Go Report Card](https://goreportcard.com/badge/github.com/Financial-Times/draft-annotations-api)](https://goreportcard.com/report/github.com/Financial-Times/draft-annotations-api) [![Coverage Status](https://coveralls.io/repos/github/Financial-Times/draft-annotations-api/badge.svg)](https://coveralls.io/github/Financial-Times/draft-annotations-api)
 

--- a/annotations/handler.go
+++ b/annotations/handler.go
@@ -2,7 +2,7 @@ package annotations
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -42,5 +42,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func writeMessage(w http.ResponseWriter, msg string, status int) {
 	w.WriteHeader(status)
-	w.Write([]byte(fmt.Sprintf(`{"message":"%v"}`, msg)))
+
+	message := make(map[string]interface{})
+	message["message"] = msg
+	j, err := json.Marshal(&message)
+
+	if err != nil {
+		log.WithError(err).Warn("Failed to parse provided message to json, this is a bug.")
+		return
+	}
+
+	w.Write(j)
 }

--- a/annotations/handler.go
+++ b/annotations/handler.go
@@ -2,6 +2,7 @@ package annotations
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -31,7 +32,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	} else {
+		writeMessage(w, "Service unavailable", http.StatusServiceUnavailable)
+	}
+}
 
-	io.Copy(w, resp.Body)
+func writeMessage(w http.ResponseWriter, msg string, status int) {
+	w.WriteHeader(status)
+	w.Write([]byte(fmt.Sprintf(`{"message":"%v"}`, msg)))
 }


### PR DESCRIPTION
The same way as the `/drafts/content` endpoint