### PR TITLE
Add a PUT endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /vendor/*
 !/vendor/vendor.json
 *.exe
+
+.idea/

--- a/annotations/canonicalizer.go
+++ b/annotations/canonicalizer.go
@@ -1,0 +1,68 @@
+package annotations
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+type Canonicalizer struct {
+	sorterFactory func(ann []Annotation) sort.Interface
+}
+
+type annotationSorter struct {
+	ann []Annotation
+}
+
+func NewCanonicalizer(sorterFactory func(ann []Annotation) sort.Interface) *Canonicalizer {
+	return &Canonicalizer{sorterFactory}
+}
+
+func (c *Canonicalizer) canonicalize(in []Annotation) []Annotation {
+	out := make([]Annotation, len(in))
+	for i, ann := range in {
+		out[i] = *c.deplete(ann)
+	}
+
+	sort.Sort(c.sorterFactory(out))
+	return out
+}
+
+func (c *Canonicalizer) deplete(in Annotation) *Annotation {
+	return &Annotation{Predicate: in.Predicate, ConceptId: in.ConceptId}
+}
+
+// Hash hashes the given payload in SHA224 + Hex
+func (c *Canonicalizer) hash(ann []Annotation) string {
+	out := bytes.NewBuffer([]byte{})
+	canonical := c.canonicalize(ann)
+	json.NewEncoder(out).Encode(canonical)
+	hash := sha256.New224()
+	hash.Write(out.Bytes())
+
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func NewCanonicalAnnotationSorter(ann []Annotation) sort.Interface {
+	return &annotationSorter{ann}
+}
+
+func (s *annotationSorter) Len() int {
+	return len(s.ann)
+}
+
+func (s *annotationSorter) Less(i, j int) bool {
+	compare := strings.Compare(s.ann[i].Predicate, s.ann[j].Predicate)
+	if compare == 0 {
+		compare = strings.Compare(s.ann[i].ConceptId, s.ann[j].ConceptId)
+	}
+
+	return compare == -1
+}
+
+func (s *annotationSorter) Swap(i, j int) {
+	s.ann[i], s.ann[j] = s.ann[j], s.ann[i]
+}

--- a/annotations/canonicalizer_test.go
+++ b/annotations/canonicalizer_test.go
@@ -1,0 +1,240 @@
+package annotations
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	about    = "http://www.ft.com/ontology/annotation/about"
+	mentions = "http://www.ft.com/ontology/annotation/mentions"
+
+	thing    = "http://www.ft.com/ontology/core/Thing"
+	concept  = "http://www.ft.com/ontology/core/Concept"
+	testType = "http://www.ft.com/ontology/TestType"
+)
+
+func TestCanonicalAnnotationSorterOrderByPredicate(t *testing.T) {
+	conceptUuid := []string{
+		uuid.NewV4().String(),
+		uuid.NewV4().String(),
+	}
+
+	// not in order
+	annotations := []Annotation{
+		{
+			Predicate: mentions,
+			ConceptId: conceptUuid[0],
+		},
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[1],
+		},
+	}
+
+	sorter := NewCanonicalAnnotationSorter(annotations)
+	sort.Sort(sorter)
+
+	assert.Equal(t, about, annotations[0].Predicate, "first annotation predicate")
+	assert.Equal(t, conceptUuid[1], annotations[0].ConceptId, "first annotation concept id")
+	assert.Equal(t, mentions, annotations[1].Predicate, "second annotation predicate")
+	assert.Equal(t, conceptUuid[0], annotations[1].ConceptId, "second annotation concept id")
+
+	// already in order
+	annotations = []Annotation{
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[0],
+		},
+		{
+			Predicate: mentions,
+			ConceptId: conceptUuid[1],
+		},
+	}
+
+	sorter = NewCanonicalAnnotationSorter(annotations)
+	sort.Sort(sorter)
+
+	assert.Equal(t, about, annotations[0].Predicate, "first annotation predicate")
+	assert.Equal(t, conceptUuid[0], annotations[0].ConceptId, "first annotation concept id")
+	assert.Equal(t, mentions, annotations[1].Predicate, "second annotation predicate")
+	assert.Equal(t, conceptUuid[1], annotations[1].ConceptId, "second annotation concept id")
+}
+
+func TestCanonicalAnnotationSorterEqualPredicateOrderByUUID(t *testing.T) {
+	conceptUuid := []string{
+		uuid.NewV4().String(),
+		uuid.NewV4().String(),
+	}
+
+	if strings.Compare(conceptUuid[0], conceptUuid[1]) == -1 {
+		// swap so that [0] is definitely later lexicographically than [1]
+		conceptUuid[0], conceptUuid[1] = conceptUuid[1], conceptUuid[0]
+	}
+
+	annotations := []Annotation{
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[0],
+		},
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[1],
+		},
+	}
+
+	sorter := NewCanonicalAnnotationSorter(annotations)
+	sort.Sort(sorter)
+
+	assert.Equal(t, about, annotations[0].Predicate, "first annotation predicate")
+	assert.Equal(t, conceptUuid[1], annotations[0].ConceptId, "first annotation concept id")
+	assert.Equal(t, about, annotations[1].Predicate, "second annotation predicate")
+	assert.Equal(t, conceptUuid[0], annotations[1].ConceptId, "second annotation concept id")
+
+	// swap round so that they are in order
+	conceptUuid[0], conceptUuid[1] = conceptUuid[1], conceptUuid[0]
+
+	annotations = []Annotation{
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[0],
+		},
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[1],
+		},
+	}
+
+	sorter = NewCanonicalAnnotationSorter(annotations)
+	sort.Sort(sorter)
+
+	assert.Equal(t, about, annotations[0].Predicate, "first annotation predicate")
+	assert.Equal(t, conceptUuid[0], annotations[0].ConceptId, "first annotation concept id")
+	assert.Equal(t, about, annotations[1].Predicate, "second annotation predicate")
+	assert.Equal(t, conceptUuid[1], annotations[1].ConceptId, "second annotation concept id")
+}
+
+func TestCanonicalizer(t *testing.T) {
+	conceptUuid := []string{
+		uuid.NewV4().String(),
+		uuid.NewV4().String(),
+	}
+
+	apiUrl := make([]string, len(conceptUuid))
+	for i, id := range conceptUuid {
+		apiUrl[i] = fmt.Sprintf("http://www.ft.com/thing/%s", id)
+	}
+
+	types := []string{thing, concept, testType}
+
+	prefLabel := []string{
+		"Some concept",
+		"Some other concept",
+	}
+
+	annotations := []Annotation{
+		{
+			mentions,
+			conceptUuid[0],
+			apiUrl[0],
+			types,
+			prefLabel[0],
+		},
+		{
+			about,
+			conceptUuid[1],
+			apiUrl[1],
+			types,
+			prefLabel[1],
+		},
+	}
+
+	c14n := NewCanonicalizer(NewCanonicalAnnotationSorter)
+	actual := c14n.canonicalize(annotations)
+
+	assert.Equal(t, about, actual[0].Predicate, "first c14n annotation predicate")
+	assert.Equal(t, conceptUuid[1], actual[0].ConceptId, "first c14n annotation concept id")
+	assert.Empty(t, actual[0].ApiUrl, "first c14n annotation apiUrl")
+	assert.Empty(t, actual[0].Types, "first c14n annotation types")
+	assert.Empty(t, actual[0].PrefLabel, "first c14n annotation prefLabel")
+
+	assert.Equal(t, mentions, actual[1].Predicate, "second c14n annotation predicate")
+	assert.Equal(t, conceptUuid[0], actual[1].ConceptId, "second c14n annotation concept id")
+	assert.Empty(t, actual[1].ApiUrl, "second c14n annotation apiUrl")
+	assert.Empty(t, actual[1].Types, "second c14n annotation types")
+	assert.Empty(t, actual[1].PrefLabel, "second c14n annotation prefLabel")
+
+	// but the original annotation structs must not have been altered
+	assert.Equal(t, mentions, annotations[0].Predicate, "first annotation predicate")
+	assert.Equal(t, conceptUuid[0], annotations[0].ConceptId, "first annotation concept id")
+	assert.Equal(t, apiUrl[0], annotations[0].ApiUrl, "first annotation apiUrl")
+	assert.Equal(t, types, annotations[0].Types, "first annotation types")
+	assert.Equal(t, prefLabel[0], annotations[0].PrefLabel, "first annotation prefLabel")
+
+	assert.Equal(t, about, annotations[1].Predicate, "second annotation predicate")
+	assert.Equal(t, conceptUuid[1], annotations[1].ConceptId, "second annotation concept id")
+	assert.Equal(t, apiUrl[1], annotations[1].ApiUrl, "second annotation apiUrl")
+	assert.Equal(t, types, annotations[1].Types, "second annotation types")
+	assert.Equal(t, prefLabel[1], annotations[1].PrefLabel, "second annotation prefLabel")
+}
+
+func TestCanonicalizerHash(t *testing.T) {
+	conceptUuid := []string{
+		uuid.NewV4().String(),
+		uuid.NewV4().String(),
+	}
+
+	apiUrl := make([]string, len(conceptUuid))
+	for i, id := range conceptUuid {
+		apiUrl[i] = fmt.Sprintf("http://www.ft.com/thing/%s", id)
+	}
+
+	types := []string{thing, concept, testType}
+
+	prefLabel := []string{
+		"Some concept",
+		"Some other concept",
+	}
+
+	annotations1 := []Annotation{
+		{
+			mentions,
+			conceptUuid[0],
+			apiUrl[0],
+			types,
+			prefLabel[0],
+		},
+		{
+			about,
+			conceptUuid[1],
+			apiUrl[1],
+			types,
+			prefLabel[1],
+		},
+	}
+
+	annotations2 := []Annotation{
+		{
+			Predicate: about,
+			ConceptId: conceptUuid[1],
+			Types:     types,
+			PrefLabel: "bar",
+		},
+		{
+			Predicate: mentions,
+			ConceptId: conceptUuid[0],
+			ApiUrl:    apiUrl[0],
+			PrefLabel: "foo",
+		},
+	}
+
+	c14n := NewCanonicalizer(NewCanonicalAnnotationSorter)
+	h1 := c14n.hash(annotations1)
+	h2 := c14n.hash(annotations2)
+	assert.Equal(t, h1, h2, "canonical hash values")
+}

--- a/annotations/model.go
+++ b/annotations/model.go
@@ -1,0 +1,9 @@
+package annotations
+
+type Annotation struct {
+	Predicate string   `json:"predicate"`
+	ConceptId string   `json:"id"`
+	ApiUrl    string   `json:"apiUrl,omitempty"`
+	Types     []string `json:"types,omitempty"`
+	PrefLabel string   `json:"prefLabel,omitempty"`
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -95,6 +95,14 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
+			"checksumSHA1": "0dBPHpFvFSF9U8wu1k4q9nHPc7U=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "879c5887cd475cd7864858769793b2ceb0d44feb",
+			"revisionTime": "2016-06-07T14:43:47Z",
+			"version": "v1.1.0",
+			"versionExact": "v1.1.0"
+		},
+		{
 			"checksumSHA1": "IVurU/0OPiDHP+JrmQ1JyAx7jng=",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "a3f95b5c423586578a4e099b11a46c2479628cac",


### PR DESCRIPTION
Presently the endpoint does nothing but canonicalize the annotations.

Canonicalization ensures that the same set of (Predicate,ConceptId) values will be considered to represent the same set of annotations (with hash calculations returning the same value), irrespective of the order in which they are presented by the client, and irrespective of additional mutable fields such as prefLabel.

For canonicalization, annotations are sorted lexicographically, first by Predicate, and then by ConceptId within a set of values for the same Predicate. (Strictly the specification doesn't need to be known externally, as only this service will ever calculate it. It just needs to be reproducible.)