### PR TITLE
Change r/w format

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,31 +88,31 @@ Fetching published annotations is part of the strategy for dynamic importing leg
 This is an example of response body:
 ```
 {
-  "annotations":[
-  {
-    "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-    "id": "http://www.ft.com/thing/fd6734a1-3ae2-30f3-98a1-e373f8da8bf1",
-    "apiUrl": "http://api.ft.com/people/fd6734a1-3ae2-30f3-98a1-e373f8da8bf1",
-    "type": "http://www.ft.com/ontology/person/Person",
-    "prefLabel": "Emily Cadman",
-    "isFTAuthor": true,
-  },
-  {
-    "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
-    "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
-    "apiUrl": "http://api.ft.com/people/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
-    "type": "http://www.ft.com/ontology/person/Person",
-    "prefLabel": "Lisa Barrett",
-    "isFTAuthor": true,
-  },
-  {
-    "predicate": "http://www.ft.com/ontology/annotation/about",
-    "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-    "apiUrl": "http://api.ft.com/things/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-    "type": "http://www.ft.com/ontology/Topic",
-    "prefLabel": "Global economic growth"
-  }
-]
+      "annotations":[
+      {
+        "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
+        "id": "http://www.ft.com/thing/fd6734a1-3ae2-30f3-98a1-e373f8da8bf1",
+        "apiUrl": "http://api.ft.com/people/fd6734a1-3ae2-30f3-98a1-e373f8da8bf1",
+        "type": "http://www.ft.com/ontology/person/Person",
+        "prefLabel": "Emily Cadman",
+        "isFTAuthor": true,
+      },
+      {
+        "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
+        "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
+        "apiUrl": "http://api.ft.com/people/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
+        "type": "http://www.ft.com/ontology/person/Person",
+        "prefLabel": "Lisa Barrett",
+        "isFTAuthor": true,
+      },
+      {
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+        "apiUrl": "http://api.ft.com/things/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+        "type": "http://www.ft.com/ontology/Topic",
+        "prefLabel": "Global economic growth"
+      }
+    ]
 }
 ```
 
@@ -123,29 +123,29 @@ Using curl:
 curl -X PUT \
   http://localhost:8080/drafts/content/{content-uuid}/annotations \
   -d '{
-        "annotations":[
-        {
-          "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
-          "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
-          "apiUrl": "http://api.ft.com/people/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
-          "type": "http://www.ft.com/ontology/person/Person",
-          "prefLabel": "Lisa Barrett"
-        },
-        {
-          "predicate": "http://www.ft.com/ontology/annotation/about",
-          "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-          "apiUrl": "http://api.ft.com/things/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-          "type": "http://www.ft.com/ontology/Topic",
-          "prefLabel": "Global economic growth"
-        },
-        {
-          "predicate": "http://www.ft.com/ontology/annotation/hasDisplayTag",
-          "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-          "apiUrl": "http://api.ft.com/things/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-          "type": "http://www.ft.com/ontology/Topic",
-          "prefLabel": "Global economic growth"
-        }
-      ]
+            "annotations":[
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
+              "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
+              "apiUrl": "http://api.ft.com/people/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
+              "type": "http://www.ft.com/ontology/person/Person",
+              "prefLabel": "Lisa Barrett"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+              "apiUrl": "http://api.ft.com/things/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+              "type": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Global economic growth"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/hasDisplayTag",
+              "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+              "apiUrl": "http://api.ft.com/things/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+              "type": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Global economic growth"
+            }
+          ]
       }'
 ```
 
@@ -157,20 +157,20 @@ The listings below shows an example of canonicalized response.
 
 ```
 {
-  "annotations":[
-  {
-    "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
-    "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
-  },
-  {
-    "predicate": "http://www.ft.com/ontology/annotation/about",
-    "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-  },
-  {
-    "predicate": "http://www.ft.com/ontology/annotation/hasDisplayTag",
-    "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
-  }
-]
+      "annotations":[
+      {
+        "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
+        "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
+      },
+      {
+        "predicate": "http://www.ft.com/ontology/annotation/about",
+        "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+      },
+      {
+        "predicate": "http://www.ft.com/ontology/annotation/hasDisplayTag",
+        "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
+      }
+    ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Options:
   --app-system-code="draft-annotations-api"                                    System Code of the application ($APP_SYSTEM_CODE)
   --app-name="draft-annotations-api"                                           Application name ($APP_NAME)
   --port="8080"                                                                Port to listen on ($APP_PORT)
-  --annotations-rw-endpoint="http://localhost:8888"                            Endpoint to get concepts from UPP ($ANNOTATIONS_RW_ENDPOINT)
+  --annotations-rw-endpoint="http://localhost:8888"                            Endpoint to get concepts from PAC ($ANNOTATIONS_RW_ENDPOINT)
   --upp-annotations-endpoint="http://test.api.ft.com/content/%v/annotations"   Endpoint to get annotations from UPP ($ANNOTATIONS_ENDPOINT)
   --concept-search-endpoint="http://test.api.ft.com/concepts"                  Endpoint to get concepts from UPP ($CONCEPT_SEARCH_ENDPOINT)
   --concept-search-batch-size=30                                               Concept IDs batch size to concept search API ($CONCEPT_SEARCH_BATCH_SIZE)
@@ -87,7 +87,8 @@ Fetching published annotations is part of the strategy for dynamic importing leg
 
 This is an example of response body:
 ```
-[
+{
+  "annotations":[
   {
     "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
     "id": "http://www.ft.com/thing/fd6734a1-3ae2-30f3-98a1-e373f8da8bf1",
@@ -112,6 +113,7 @@ This is an example of response body:
     "prefLabel": "Global economic growth"
   }
 ]
+}
 ```
 
 ### PUT - Writing draft annotations to PAC
@@ -120,7 +122,8 @@ Using curl:
 ```
 curl -X PUT \
   http://localhost:8080/drafts/content/{content-uuid}/annotations \
-  -d '[
+  -d '{
+        "annotations":[
         {
           "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
           "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
@@ -142,7 +145,8 @@ curl -X PUT \
           "type": "http://www.ft.com/ontology/Topic",
           "prefLabel": "Global economic growth"
         }
-      ]'
+      ]
+      }'
 ```
 
 A PUT request on this endpoint writes the draft annotations in PAC. 
@@ -152,7 +156,8 @@ a HTTP 200 response code.
 The listings below shows an example of canonicalized response.
 
 ```
-[
+{
+  "annotations":[
   {
     "predicate": "http://www.ft.com/ontology/annotation/hasContributor",
     "id": "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
@@ -166,6 +171,7 @@ The listings below shows an example of canonicalized response.
     "id": "http://www.ft.com/thing/d7de27f8-1633-3fcc-b308-c95a2ad7d1cd",
   }
 ]
+}
 ```
 
 ## Healthchecks

--- a/annotations/model.go
+++ b/annotations/model.go
@@ -1,5 +1,9 @@
 package annotations
 
+type Annotations struct {
+	Annotations []Annotation `json:"annotations"`
+}
+
 type Annotation struct {
 	Predicate  string `json:"predicate"`
 	ConceptId  string `json:"id"`

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -57,7 +57,7 @@ func (h *Handler) ReadAnnotations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set(annotations.DocumentHashHeader, hash)
-		json.NewEncoder(w).Encode(augmentedAnnotations)
+		json.NewEncoder(w).Encode(map[string]interface{}{"annotations":augmentedAnnotations})
 		return
 	} else {
 		readLog.Info("Annotations not found: Retrieving annotations from UPP")

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -28,9 +29,9 @@ func TestHappyFetchFromAnnotationsRW(t *testing.T) {
 	hash := randomdata.RandStringRunes(56)
 
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(expectedAnnotations, hash, true, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(&expectedAnnotations, hash, true, nil)
 	aug := new(AugmenterMock)
-	aug.On("AugmentAnnotations", mock.Anything, expectedAnnotations).Return(expectedAnnotations, nil)
+	aug.On("AugmentAnnotations", mock.Anything, expectedAnnotations.Annotations).Return(expectedAnnotations.Annotations, nil)
 	annAPI := new(AnnotationsAPIMock)
 
 	h := New(rw, annAPI, nil, aug)
@@ -45,11 +46,11 @@ func TestHappyFetchFromAnnotationsRW(t *testing.T) {
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	actual := make(map[string][]annotations.Annotation)
+	actual := annotations.Annotations{}
 	err := json.NewDecoder(resp.Body).Decode(&actual)
 	assert.NoError(t, err)
 
-	assert.Equal(t, expectedAnnotations, actual["annotations"])
+	assert.Equal(t, expectedAnnotations, actual)
 	assert.Equal(t, hash, resp.Header.Get(annotations.DocumentHashHeader))
 
 	rw.AssertExpectations(t)
@@ -59,7 +60,7 @@ func TestHappyFetchFromAnnotationsRW(t *testing.T) {
 
 func TestUnHappyFetchFromAnnotationsRW(t *testing.T) {
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, errors.New("computer says no"))
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, errors.New("computer says no"))
 	aug := new(AugmenterMock)
 	annAPI := new(AnnotationsAPIMock)
 
@@ -87,9 +88,9 @@ func TestUnHappyFetchFromAnnotationsRW(t *testing.T) {
 
 func TestUnHappyAugmenter(t *testing.T) {
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(expectedAnnotations, "", true, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(&expectedAnnotations, "", true, nil)
 	aug := new(AugmenterMock)
-	aug.On("AugmentAnnotations", mock.Anything, expectedAnnotations).Return([]annotations.Annotation{}, errors.New("computer says no"))
+	aug.On("AugmentAnnotations", mock.Anything, expectedAnnotations.Annotations).Return([]annotations.Annotation{}, errors.New("computer says no"))
 	annAPI := new(AnnotationsAPIMock)
 
 	h := New(rw, annAPI, nil, aug)
@@ -118,7 +119,7 @@ func TestFetchFromAnnotationsAPIIfNotFoundInRW(t *testing.T) {
 	aug := new(AugmenterMock)
 	rw := new(RWMock)
 
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, nil)
 
 	annotationsAPIServerMock := newAnnotationsAPIServerMock(t, http.StatusOK, annotationsAPIBody)
 	defer annotationsAPIServerMock.Close()
@@ -149,7 +150,7 @@ func TestFetchFromAnnotationsAPIIfNotFoundInRW(t *testing.T) {
 func TestFetchFromAnnotationsAPI404(t *testing.T) {
 	aug := new(AugmenterMock)
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, nil)
 
 	annotationsAPIServerMock := newAnnotationsAPIServerMock(t, http.StatusNotFound, "not found")
 	defer annotationsAPIServerMock.Close()
@@ -177,7 +178,7 @@ func TestFetchFromAnnotationsAPI404(t *testing.T) {
 
 func TestFetchFromAnnotationsAPI404NoAnnoPostMapping(t *testing.T) {
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, nil)
 	aug := new(AugmenterMock)
 
 	annotationsAPIServerMock := newAnnotationsAPIServerMock(t, http.StatusOK, bannedAnnotationsAPIBody)
@@ -206,7 +207,7 @@ func TestFetchFromAnnotationsAPI404NoAnnoPostMapping(t *testing.T) {
 
 func TestFetchFromAnnotationsAPI500(t *testing.T) {
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, nil)
 	aug := new(AugmenterMock)
 	annotationsAPIServerMock := newAnnotationsAPIServerMock(t, http.StatusInternalServerError, "fire!")
 	defer annotationsAPIServerMock.Close()
@@ -234,7 +235,7 @@ func TestFetchFromAnnotationsAPI500(t *testing.T) {
 
 func TestFetchFromAnnotationsAPIWithInvalidURL(t *testing.T) {
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, nil)
 	aug := new(AugmenterMock)
 	annotationsAPI := annotations.NewUPPAnnotationsAPI(":#", testAPIKey)
 	h := New(rw, annotationsAPI, nil, aug)
@@ -259,7 +260,7 @@ func TestFetchFromAnnotationsAPIWithInvalidURL(t *testing.T) {
 
 func TestFetchFromAnnotationsAPIWithConnectionError(t *testing.T) {
 	rw := new(RWMock)
-	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return([]annotations.Annotation{}, "", false, nil)
+	rw.On("Read", mock.Anything, "83a201c6-60cd-11e7-91a7-502f7ee26895").Return(nil, "", false, nil)
 	aug := new(AugmenterMock)
 	annotationsAPIServerMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	annotationsAPIServerMock.Close()
@@ -353,42 +354,35 @@ const expectedAnnotationsBody = `[
       "prefLabel": "David J Lynch"
    }
 ]`
-var expectedAnnotations = []annotations.Annotation{
-	{
-		Predicate: "http://www.ft.com/ontology/annotation/mentions",
-		ConceptId: "http://www.ft.com/thing/0a619d71-9af5-3755-90dd-f789b686c67a",
-		ApiUrl: "http://api.ft.com/people/0a619d71-9af5-3755-90dd-f789b686c67a",
-		Type: "http://www.ft.com/ontology/person/Person",
-		PrefLabel: "Barack H. Obama",
-	},
-	{
-		Predicate: "http://www.ft.com/ontology/annotation/hasAuthor",
-		ConceptId: "http://www.ft.com/thing/838b3fbe-efbc-3cfe-b5c0-d38c046492a4",
-		ApiUrl: "http://api.ft.com/people/838b3fbe-efbc-3cfe-b5c0-d38c046492a4",
-		Type: "http://www.ft.com/ontology/person/Person",
-		PrefLabel: "David J Lynch",
+var expectedAnnotations = annotations.Annotations{
+	[]annotations.Annotation{
+		{
+			Predicate: "http://www.ft.com/ontology/annotation/mentions",
+			ConceptId: "http://www.ft.com/thing/0a619d71-9af5-3755-90dd-f789b686c67a",
+			ApiUrl:    "http://api.ft.com/people/0a619d71-9af5-3755-90dd-f789b686c67a",
+			Type:      "http://www.ft.com/ontology/person/Person",
+			PrefLabel: "Barack H. Obama",
+		},
+		{
+			Predicate: "http://www.ft.com/ontology/annotation/hasAuthor",
+			ConceptId: "http://www.ft.com/thing/838b3fbe-efbc-3cfe-b5c0-d38c046492a4",
+			ApiUrl:    "http://api.ft.com/people/838b3fbe-efbc-3cfe-b5c0-d38c046492a4",
+			Type:      "http://www.ft.com/ontology/person/Person",
+			PrefLabel: "David J Lynch",
+		},
 	},
 }
 
-const expectedCanonicalisedAnnotationsBody = `[
-   {
-      "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-      "id": "http://www.ft.com/thing/838b3fbe-efbc-3cfe-b5c0-d38c046492a4"
-   },
-   {
-      "predicate": "http://www.ft.com/ontology/annotation/mentions",
-      "id": "http://www.ft.com/thing/0a619d71-9af5-3755-90dd-f789b686c67a"
-   }
-]`
-
-var expectedDepletedAnnotations = []annotations.Annotation{
-	{
-		Predicate: "http://www.ft.com/ontology/annotation/hasAuthor",
-		ConceptId: "http://www.ft.com/thing/838b3fbe-efbc-3cfe-b5c0-d38c046492a4",
-	},
-	{
-		Predicate: "http://www.ft.com/ontology/annotation/mentions",
-		ConceptId: "http://www.ft.com/thing/0a619d71-9af5-3755-90dd-f789b686c67a",
+var expectedCanonicalisedAnnotationsBody = annotations.Annotations{
+	[]annotations.Annotation{
+		{
+			Predicate: "http://www.ft.com/ontology/annotation/hasAuthor",
+			ConceptId: "http://www.ft.com/thing/838b3fbe-efbc-3cfe-b5c0-d38c046492a4",
+		},
+		{
+			Predicate: "http://www.ft.com/ontology/annotation/mentions",
+			ConceptId: "http://www.ft.com/thing/0a619d71-9af5-3755-90dd-f789b686c67a",
+		},
 	},
 }
 
@@ -396,7 +390,7 @@ func TestSaveAnnotations(t *testing.T) {
 	oldHash := randomdata.RandStringRunes(56)
 	newHash := randomdata.RandStringRunes(56)
 	rw := new(RWMock)
-	rw.On("Write", mock.AnythingOfType("*context.valueCtx"), "83a201c6-60cd-11e7-91a7-502f7ee26895", expectedDepletedAnnotations, oldHash).Return(newHash, nil)
+	rw.On("Write", mock.AnythingOfType("*context.valueCtx"), "83a201c6-60cd-11e7-91a7-502f7ee26895", &expectedCanonicalisedAnnotationsBody, oldHash).Return(newHash, nil)
 
 	aug := new(AugmenterMock)
 	annotationsAPI := new(AnnotationsAPIMock)
@@ -405,10 +399,13 @@ func TestSaveAnnotations(t *testing.T) {
 	r := vestigo.NewRouter()
 	r.Put("/drafts/content/:uuid/annotations", h.WriteAnnotations)
 
+	entity := bytes.Buffer{}
+	json.NewEncoder(&entity).Encode(&expectedAnnotations)
+
 	req := httptest.NewRequest(
 		"PUT",
 		"http://api.ft.com/drafts/content/83a201c6-60cd-11e7-91a7-502f7ee26895/annotations",
-		strings.NewReader(expectedAnnotationsBody))
+		&entity)
 
 	req.Header.Set(tidutils.TransactionIDHeader, testTID)
 	req.Header.Set(annotations.PreviousDocumentHashHeader, oldHash)
@@ -416,10 +413,13 @@ func TestSaveAnnotations(t *testing.T) {
 
 	r.ServeHTTP(w, req)
 	resp := w.Result()
-	body, err := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	actual := annotations.Annotations{}
+	err := json.NewDecoder(resp.Body).Decode(&actual)
 	assert.NoError(t, err)
-	assert.JSONEq(t, string(expectedCanonicalisedAnnotationsBody), string(body))
+
+	assert.Equal(t, expectedCanonicalisedAnnotationsBody, actual)
 	assert.Equal(t, newHash, resp.Header.Get(annotations.DocumentHashHeader))
 
 	rw.AssertExpectations(t)
@@ -492,7 +492,7 @@ func TestSaveAnnotationsInvalidAnnotationsBody(t *testing.T) {
 func TestSaveAnnotationsErrorFromRW(t *testing.T) {
 	oldHash := randomdata.RandStringRunes(56)
 	rw := new(RWMock)
-	rw.On("Write", mock.AnythingOfType("*context.valueCtx"), "83a201c6-60cd-11e7-91a7-502f7ee26895", expectedDepletedAnnotations, oldHash).Return("", errors.New("computer says no"))
+	rw.On("Write", mock.AnythingOfType("*context.valueCtx"), "83a201c6-60cd-11e7-91a7-502f7ee26895", &expectedCanonicalisedAnnotationsBody, oldHash).Return("", errors.New("computer says no"))
 
 	aug := new(AugmenterMock)
 	annotationsAPI := new(AnnotationsAPIMock)
@@ -501,10 +501,13 @@ func TestSaveAnnotationsErrorFromRW(t *testing.T) {
 	r := vestigo.NewRouter()
 	r.Put("/drafts/content/:uuid/annotations", h.WriteAnnotations)
 
+	entity := bytes.Buffer{}
+	json.NewEncoder(&entity).Encode(&expectedAnnotations)
+
 	req := httptest.NewRequest(
 		"PUT",
 		"http://api.ft.com/drafts/content/83a201c6-60cd-11e7-91a7-502f7ee26895/annotations",
-		strings.NewReader(expectedAnnotationsBody))
+		&entity)
 
 	req.Header.Set(tidutils.TransactionIDHeader, testTID)
 	req.Header.Set(annotations.PreviousDocumentHashHeader, oldHash)
@@ -535,12 +538,18 @@ type RWMock struct {
 	mock.Mock
 }
 
-func (m *RWMock) Read(ctx context.Context, contentUUID string) ([]annotations.Annotation, string, bool, error) {
+func (m *RWMock) Read(ctx context.Context, contentUUID string) (*annotations.Annotations, string, bool, error) {
 	args := m.Called(ctx, contentUUID)
-	return args.Get(0).([]annotations.Annotation), args.String(1), args.Bool(2), args.Error(3)
+
+	var ann *annotations.Annotations
+	if v := args.Get(0); v != nil {
+		ann = v.(*annotations.Annotations)
+	}
+
+	return ann, args.String(1), args.Bool(2), args.Error(3)
 }
 
-func (m *RWMock) Write(ctx context.Context, contentUUID string, a []annotations.Annotation, hash string) (string, error) {
+func (m *RWMock) Write(ctx context.Context, contentUUID string, a *annotations.Annotations, hash string) (string, error) {
 	args := m.Called(ctx, contentUUID, a, hash)
 	return args.String(0), args.Error(1)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -149,7 +149,7 @@
 			"revisionTime": "2017-07-18T17:12:47Z"
 		},
 		{
-			"checksumSHA1": "vlicYp+fe4ECQ+5QqpAk36VRA3s=",
+			"checksumSHA1": "lzKN/3F0mwa8tLTOD/9zG5H1rN0=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "cd2c276457edda6df7fb04895d3fd6a6add42926",
 			"revisionTime": "2017-07-17T10:05:24Z"


### PR DESCRIPTION
Changing the format of the JSON documents so that both r/w and publish use a JSON object with an `annotations` property.