### PR TITLE
uppsf-892 Impleement translation from isClassifiedBy to HasBrand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
   dredd:
     working_directory: /go/src/github.com/Financial-Times/draft-annotations-api
     docker:
-      - image: bankrs/golang-dredd:latest
+      - image: golang:1
         environment:
           GOPATH: /go
           API_YML: /go/src/github.com/Financial-Times/draft-annotations-api/_ft/api.yml
@@ -60,7 +60,17 @@ jobs:
       - checkout
       - run:
           name: Go Build
-          command: go build -mod=readonly -v
+          command: go build -v
+      - run:
+          name: Load ersatz-fixtures.yml to ersatz image
+          command: "curl -X POST --data-binary @_ft/ersatz-fixtures.yml -H \"Content-type: text/x-yaml\" http://localhost:9000/__configure"
+      - run:
+          name: Download dredd
+          command: |
+            curl -sL https://deb.nodesource.com/setup_11.x | bash -
+            DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs=11.\*
+            npm install -g --unsafe-perm --loglevel warn --user 0 --no-progress dredd@8.0.0
+            rm -rf /var/lib/apt/lists/*
       - run:
           name: Dredd API Testing
           command: dredd

--- a/_ft/api.yml
+++ b/_ft/api.yml
@@ -61,7 +61,7 @@ paths:
           description: The UUID of the content
           required: true
           type: string
-          x-example: f368bbac-4bd9-11e7-919a-1e14ce4af89b
+          x-example: 8df16ae8-0dfd-4859-a5ff-eeb9644bed35
         - name: body
           in: body
           required: true

--- a/_ft/ersatz-fixtures.yml
+++ b/_ft/ersatz-fixtures.yml
@@ -10,6 +10,10 @@ fixtures:
             ids: ababe00a-d732-4690-b283-585e7f264d2f
         - queryParams:
             ids: dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54
+        - queryParams:
+            ids: 5507ab98-b747-3ebc-b816-11603b9009f4
+        - queryParams:
+            ids: d7113d1d-ed66-3adf-9910-1f62b2c40e6a
       body:
         concepts:
           ababe00a-d732-4690-b283-585e7f264d2f:
@@ -17,7 +21,11 @@ fixtures:
             apiUrl: http://api.ft.com/things/6b43a14b-a5e0-3b63-a428-aa55def05fcb
             prefLabel: FT Confidential Research
             type: http://www.ft.com/ontology/Section
-            concordances: [{"authority":"http://api.ft.com/system/UPP","identifierValue":"e67785b2-8b74-3500-962a-747cee5cbea4"},{"authority":"http://api.ft.com/system/UPP","identifierValue":"f0c5efd3-a0f4-3ac2-92af-e26e9ccfebbe"},{"authority":"http://api.ft.com/system/SMARTLOGIC","identifierValue":"5ede5a4b-e3bd-4578-89d2-78b97012eb6a"},{"authority":"http://api.ft.com/system/FT-TME","identifierValue":"ZGYwZjY5MTQtNmU5YS00MGI5LWE3NTctNzE1NDM2M2I2ODdk-VG9waWNz"}]
+          5507ab98-b747-3ebc-b816-11603b9009f4:
+            id: http://api.ft.com/things/5507ab98-b747-3ebc-b816-11603b9009f4
+            apiUrl: http://api.ft.com/things/5507ab98-b747-3ebc-b816-11603b9009f4
+            type: http://www.ft.com/ontology/Topic
+            prefLabel: Technology sector
   /drafts/content/8df16ae8-0dfd-4859-a5ff-eeb9644bed35/annotations:
     get:
       status: 200
@@ -27,9 +35,6 @@ fixtures:
         annotations:
           - id: http://www.ft.com/thing/ababe00a-d732-4690-b283-585e7f264d2f
             predicate: http://www.ft.com/ontology/annotation/mentions
-    put:
-      status: 200
-  /drafts/content/f368bbac-4bd9-11e7-919a-1e14ce4af89b/annotations:
     put:
       status: 200
   /content/4f2f97ea-b8ec-11e4-b8e6-00144feab7de/annotations:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Financial-Times/draft-annotations-api
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Financial-Times/api-endpoint v0.0.0-20170612095945-d9f326a291cc

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -354,11 +354,7 @@ func (h *Handler) readAnnotations(ctx context.Context, contentUUID string, showH
 	}
 
 	if !showHasBrand {
-		result, err = switchToIsClassifiedBy(result)
-		if err != nil {
-			readLog.WithError(err).Error("Failed to hide hasBrand annotations")
-			return nil, hash, err
-		}
+		result = switchToIsClassifiedBy(result)
 	}
 
 	return result, hash, err
@@ -469,7 +465,7 @@ func switchToHasBrand(toChange []annotations.Annotation) ([]annotations.Annotati
 	return changed, nil
 }
 
-func switchToIsClassifiedBy(toChange []annotations.Annotation) ([]annotations.Annotation, error) {
+func switchToIsClassifiedBy(toChange []annotations.Annotation) []annotations.Annotation {
 	changed := make([]annotations.Annotation, len(toChange))
 	for idx, ann := range toChange {
 		if ann.Predicate == mapper.PredicateHasBrand {
@@ -477,5 +473,5 @@ func switchToIsClassifiedBy(toChange []annotations.Annotation) ([]annotations.An
 		}
 		changed[idx] = ann
 	}
-	return changed, nil
+	return changed
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -455,7 +455,7 @@ func switchToHasBrand(toChange []annotations.Annotation) ([]annotations.Annotati
 			return nil, fmt.Errorf("index %d : annotation missing concept type", idx)
 		}
 
-		if ann.Predicate == mapper.PREDICATE_IS_CLASSIFIED_BY && ann.Type == mapper.CONCEPT_TYPE_BRAND {
+		if ann.Predicate == mapper.PredicateIsClassifiedBy && ann.Type == mapper.ConceptTypeBrand {
 			ann.Predicate = mapper.PredicateHasBrand
 		}
 
@@ -469,7 +469,7 @@ func switchToIsClassifiedBy(toChange []annotations.Annotation) ([]annotations.An
 	changed := make([]annotations.Annotation, len(toChange))
 	for idx, ann := range toChange {
 		if ann.Predicate == mapper.PredicateHasBrand {
-			ann.Predicate = mapper.PREDICATE_IS_CLASSIFIED_BY
+			ann.Predicate = mapper.PredicateIsClassifiedBy
 		}
 		changed[idx] = ann
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -151,7 +151,16 @@ func (h *Handler) ReadAnnotations(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 
-	showHasBrand, _ := strconv.ParseBool(r.URL.Query().Get("sendHasBrand"))
+	showHasBrand := false
+	var err error
+	queryParam := r.URL.Query().Get("sendHasBrand")
+	if queryParam != "" {
+		showHasBrand, err = strconv.ParseBool(queryParam)
+		if err != nil {
+			writeMessage(w, fmt.Sprintf("invalid param sendHasBrand: %s ", queryParam), http.StatusBadRequest)
+			return
+		}
+	}
 
 	result, hash, err := h.readAnnotations(ctx, contentUUID, showHasBrand, readLog)
 	if err != nil {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -14,6 +14,7 @@ const PREDICATE_MAJOR_MENTIONS = "http://www.ft.com/ontology/annotation/majorMen
 const PREDICATE_ABOUT = "http://www.ft.com/ontology/annotation/about"
 const PredicateImplicitlyAbout = "http://www.ft.com/ontology/implicitlyAbout"
 const PredicateImplicitlyClassifiedBy = "http://www.ft.com/ontology/implicitlyClassifiedBy"
+const PredicateHasBrand = "http://www.ft.com/ontology/hasBrand"
 const CONCEPT_TYPE_BRAND = "http://www.ft.com/ontology/product/Brand"
 const CONCEPT_TYPE_GENRE = "http://www.ft.com/ontology/Genre"
 const CONCEPT_TYPE_TOPIC = "http://www.ft.com/ontology/Topic"


### PR DESCRIPTION
Code cleanup.
Change API: Now `draft-annotations-api` calls `internal-concordances` on PUT, POST, PUSH, DELETE and canonicalizes the annotations. 
Hide `HasBrand` annotations from TagMe.
Write `HasBrand` annotation when we send `isClassifiedBy` for `Brand` annotation.