### PR TITLE
Do not call internal-concordances for SV annotations

### DIFF
--- a/annotations/augmenter.go
+++ b/annotations/augmenter.go
@@ -50,40 +50,43 @@ func (a *Augmenter) AugmentAnnotations(ctx context.Context, canonicalAnnotations
 	origin := ctx.Value(OriginSystemIDHeaderKey(OriginSystemIDHeader)).(string)
 	if origin == PACOriginSystemID {
 		dedupedCanonical = filterOutInvalidPredicates(dedupedCanonical)
-	}
 
-	uuids := getConceptUUIDs(dedupedCanonical)
+		uuids := getConceptUUIDs(dedupedCanonical)
 
-	concepts, err := a.conceptRead.GetConceptsByIDs(ctx, uuids)
+		concepts, err := a.conceptRead.GetConceptsByIDs(ctx, uuids)
 
-	if err != nil {
-		a.log.WithTransactionID(tid).
-			WithError(err).Error("Request failed when attempting to augment annotations from UPP concept data")
-		return nil, err
-	}
-
-	augmentedAnnotations := make([]interface{}, 0)
-	for _, annotation := range dedupedCanonical {
-		ann := make(map[string]interface{})
-		maps.Copy(ann, annotation.(map[string]interface{}))
-		uuid := extractUUID(ann["id"].(string))
-		concept, found := concepts[uuid]
-		if found {
-			ann["id"] = concept.ID
-			ann["apiUrl"] = concept.ApiUrl
-			ann["prefLabel"] = concept.PrefLabel
-			ann["isFTAuthor"] = concept.IsFTAuthor
-			ann["type"] = concept.Type
-			augmentedAnnotations = append(augmentedAnnotations, ann)
-		} else {
+		if err != nil {
 			a.log.WithTransactionID(tid).
-				WithUUID(ann["id"].(string)).
-				Warn("Concept data for this annotation was not found, and will be removed from the list of annotations.")
+				WithError(err).Error("Request failed when attempting to augment annotations from UPP concept data")
+			return nil, err
 		}
+
+		augmentedAnnotations := make([]interface{}, 0)
+		for _, annotation := range dedupedCanonical {
+			ann := make(map[string]interface{})
+			maps.Copy(ann, annotation.(map[string]interface{}))
+			uuid := extractUUID(ann["id"].(string))
+			concept, found := concepts[uuid]
+			if found {
+				ann["id"] = concept.ID
+				ann["apiUrl"] = concept.ApiUrl
+				ann["prefLabel"] = concept.PrefLabel
+				ann["isFTAuthor"] = concept.IsFTAuthor
+				ann["type"] = concept.Type
+				augmentedAnnotations = append(augmentedAnnotations, ann)
+			} else {
+				a.log.WithTransactionID(tid).
+					WithUUID(ann["id"].(string)).
+					Warn("Concept data for this annotation was not found, and will be removed from the list of annotations.")
+			}
+		}
+
+		a.log.WithTransactionID(tid).Info("PAC Annotations augmented with concept data")
+		return augmentedAnnotations, nil
 	}
 
-	a.log.WithTransactionID(tid).Info("Annotations augmented with concept data")
-	return augmentedAnnotations, nil
+	a.log.WithTransactionID(tid).Info("Annotations are not eligible to be augmented with concept data")
+	return dedupedCanonical, nil
 }
 
 func dedupeCanonicalAnnotations(annotations []interface{}) ([]interface{}, error) {

--- a/annotations/augmenter_test.go
+++ b/annotations/augmenter_test.go
@@ -98,6 +98,29 @@ var expectedAugmentedAnnotations = []interface{}{
 	},
 }
 
+var expectedAugmentedAnnotationsSV = []interface{}{
+	map[string]interface{}{
+		"predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+		"id":        "http://www.ft.com/thing/b224ad07-c818-3ad6-94af-a4d351dbb619",
+	},
+	map[string]interface{}{
+		"predicate": "http://www.ft.com/ontology/annotation/mentions",
+		"id":        "http://www.ft.com/thing/1a2a1a0a-7199-38b8-8a73-e651e2172471",
+	},
+	map[string]interface{}{
+		"predicate": "http://www.ft.com/ontology/hasContributor",
+		"id":        "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
+	},
+	map[string]interface{}{
+		"predicate": "http://www.ft.com/ontology/annotation/mentions",
+		"id":        "http://www.ft.com/thing/1fb3faf1-bf00-3a15-8efb-1038a59653f7",
+	},
+	map[string]interface{}{
+		"predicate": "http://www.ft.com/ontology/annotation/mentions",
+		"id":        "http://www.ft.com/thing/7b7dafa0-d54e-4c1d-8e22-3d452792acd2",
+	},
+}
+
 var testReturnSingleConceptID = []string{
 	"b224ad07-c818-3ad6-94af-a4d351dbb619",
 }
@@ -131,6 +154,21 @@ func TestAugmentAnnotations(t *testing.T) {
 	assert.Equal(t, len(expectedAugmentedAnnotations), len(annotations))
 	assert.ElementsMatch(t, annotations, expectedAugmentedAnnotations)
 	conceptRead.AssertExpectations(t)
+}
+
+func TestAugmentAnnotationsSustainableViews(t *testing.T) {
+	conceptRead := new(ConceptReadAPIMock)
+	ctx := tidUtils.TransactionAwareContext(context.Background(), tidUtils.NewTransactionID())
+	ctx = context.WithValue(ctx, OriginSystemIDHeaderKey(OriginSystemIDHeader), "http://cmdb.ft.com/systems/spark")
+	log := logger.NewUPPLogger("draft-annotations-api", "INFO")
+	a := NewAugmenter(conceptRead, log)
+
+	annotations, err := a.AugmentAnnotations(ctx, testCanonicalizedAnnotations)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(expectedAugmentedAnnotationsSV), len(annotations))
+	assert.ElementsMatch(t, annotations, expectedAugmentedAnnotationsSV)
+	conceptRead.AssertNotCalled(t, "GetConceptsByIDs")
 }
 
 func TestAugmentAnnotationsFixtures(t *testing.T) {


### PR DESCRIPTION
# Description

## What

Do not call internal-concordances service for Sustainable Views

## Why

JIRA Ticket [UPPSF-5189](https://financialtimes.atlassian.net/browse/UPPSF-5189)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-5189]: https://financialtimes.atlassian.net/browse/UPPSF-5189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ