### PR TITLE
Revert "Do not call internal-concordances for SV annotations"

### DIFF
--- a/annotations/augmenter_test.go
+++ b/annotations/augmenter_test.go
@@ -98,29 +98,6 @@ var expectedAugmentedAnnotations = []interface{}{
 	},
 }
 
-var expectedAugmentedAnnotationsSV = []interface{}{
-	map[string]interface{}{
-		"predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-		"id":        "http://www.ft.com/thing/b224ad07-c818-3ad6-94af-a4d351dbb619",
-	},
-	map[string]interface{}{
-		"predicate": "http://www.ft.com/ontology/annotation/mentions",
-		"id":        "http://www.ft.com/thing/1a2a1a0a-7199-38b8-8a73-e651e2172471",
-	},
-	map[string]interface{}{
-		"predicate": "http://www.ft.com/ontology/hasContributor",
-		"id":        "http://www.ft.com/thing/5bd49568-6d7c-3c10-a5b0-2f3fd5974a6b",
-	},
-	map[string]interface{}{
-		"predicate": "http://www.ft.com/ontology/annotation/mentions",
-		"id":        "http://www.ft.com/thing/1fb3faf1-bf00-3a15-8efb-1038a59653f7",
-	},
-	map[string]interface{}{
-		"predicate": "http://www.ft.com/ontology/annotation/mentions",
-		"id":        "http://www.ft.com/thing/7b7dafa0-d54e-4c1d-8e22-3d452792acd2",
-	},
-}
-
 var testReturnSingleConceptID = []string{
 	"b224ad07-c818-3ad6-94af-a4d351dbb619",
 }
@@ -154,21 +131,6 @@ func TestAugmentAnnotations(t *testing.T) {
 	assert.Equal(t, len(expectedAugmentedAnnotations), len(annotations))
 	assert.ElementsMatch(t, annotations, expectedAugmentedAnnotations)
 	conceptRead.AssertExpectations(t)
-}
-
-func TestAugmentAnnotationsSustainableViews(t *testing.T) {
-	conceptRead := new(ConceptReadAPIMock)
-	ctx := tidUtils.TransactionAwareContext(context.Background(), tidUtils.NewTransactionID())
-	ctx = context.WithValue(ctx, OriginSystemIDHeaderKey(OriginSystemIDHeader), "http://cmdb.ft.com/systems/spark")
-	log := logger.NewUPPLogger("draft-annotations-api", "INFO")
-	a := NewAugmenter(conceptRead, log)
-
-	annotations, err := a.AugmentAnnotations(ctx, testCanonicalizedAnnotations)
-
-	assert.NoError(t, err)
-	assert.Equal(t, len(expectedAugmentedAnnotationsSV), len(annotations))
-	assert.ElementsMatch(t, annotations, expectedAugmentedAnnotationsSV)
-	conceptRead.AssertNotCalled(t, "GetConceptsByIDs")
 }
 
 func TestAugmentAnnotationsFixtures(t *testing.T) {


### PR DESCRIPTION
This reverts commit 2ec4d58ccce32d9508656b26e8bb99ce3599d12f.

# Description

## What

Revert "Do not call internal-concordances for SV annotations"

## Why

JIRA Ticket [UPPSF-5306](https://financialtimes.atlassian.net/browse/UPPSF-5306)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-5306]: https://financialtimes.atlassian.net/browse/UPPSF-5306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ