### PR TITLE
allow augmenting only for pac system origin id

### DIFF
--- a/annotations/augmenter.go
+++ b/annotations/augmenter.go
@@ -50,40 +50,43 @@ func (a *Augmenter) AugmentAnnotations(ctx context.Context, canonicalAnnotations
 	origin := ctx.Value(OriginSystemIDHeaderKey(OriginSystemIDHeader)).(string)
 	if origin == PACOriginSystemID {
 		dedupedCanonical = filterOutInvalidPredicates(dedupedCanonical)
-	}
 
-	uuids := getConceptUUIDs(dedupedCanonical)
+		uuids := getConceptUUIDs(dedupedCanonical)
 
-	concepts, err := a.conceptRead.GetConceptsByIDs(ctx, uuids)
+		concepts, err := a.conceptRead.GetConceptsByIDs(ctx, uuids)
 
-	if err != nil {
-		a.log.WithTransactionID(tid).
-			WithError(err).Error("Request failed when attempting to augment annotations from UPP concept data")
-		return nil, err
-	}
-
-	augmentedAnnotations := make([]interface{}, 0)
-	for _, annotation := range dedupedCanonical {
-		ann := make(map[string]interface{})
-		maps.Copy(ann, annotation.(map[string]interface{}))
-		uuid := extractUUID(ann["id"].(string))
-		concept, found := concepts[uuid]
-		if found {
-			ann["id"] = concept.ID
-			ann["apiUrl"] = concept.ApiUrl
-			ann["prefLabel"] = concept.PrefLabel
-			ann["isFTAuthor"] = concept.IsFTAuthor
-			ann["type"] = concept.Type
-			augmentedAnnotations = append(augmentedAnnotations, ann)
-		} else {
+		if err != nil {
 			a.log.WithTransactionID(tid).
-				WithUUID(ann["id"].(string)).
-				Warn("Concept data for this annotation was not found, and will be removed from the list of annotations.")
+				WithError(err).Error("Request failed when attempting to augment annotations from UPP concept data")
+			return nil, err
 		}
+
+		augmentedAnnotations := make([]interface{}, 0)
+		for _, annotation := range dedupedCanonical {
+			ann := make(map[string]interface{})
+			maps.Copy(ann, annotation.(map[string]interface{}))
+			uuid := extractUUID(ann["id"].(string))
+			concept, found := concepts[uuid]
+			if found {
+				ann["id"] = concept.ID
+				ann["apiUrl"] = concept.ApiUrl
+				ann["prefLabel"] = concept.PrefLabel
+				ann["isFTAuthor"] = concept.IsFTAuthor
+				ann["type"] = concept.Type
+				augmentedAnnotations = append(augmentedAnnotations, ann)
+			} else {
+				a.log.WithTransactionID(tid).
+					WithUUID(ann["id"].(string)).
+					Warn("Concept data for this annotation was not found, and will be removed from the list of annotations.")
+			}
+		}
+
+		a.log.WithTransactionID(tid).Info("PAC Annotations augmented with concept data")
+		return augmentedAnnotations, nil
 	}
 
-	a.log.WithTransactionID(tid).Info("Annotations augmented with concept data")
-	return augmentedAnnotations, nil
+	a.log.WithTransactionID(tid).Info("Annotations are not eligible to be augmented with concept data")
+	return dedupedCanonical, nil
 }
 
 func dedupeCanonicalAnnotations(annotations []interface{}) ([]interface{}, error) {


### PR DESCRIPTION
# Description

## What

Allow augmenting of annotations only for PAC system origin id because external publication concepts are missing from elasticsearch on PRODUCTION.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
