### PR TITLE
Match the schema in the publishing cluster

### DIFF
--- a/synchronise/synchronise.go
+++ b/synchronise/synchronise.go
@@ -23,6 +23,16 @@ const (
 	FTPinkPublication    = "88fdde6c-2aa4-4f78-af02-9f680097cfd6"
 )
 
+type AnnotationsBody struct {
+	Annotations []Annotation `json:"annotations"`
+	Publication []string     `json:"publication"`
+}
+
+type Annotation struct {
+	ID        string `json:"id"`
+	Predicate string `json:"predicate"`
+}
+
 type API struct {
 	client   *http.Client
 	username string
@@ -57,7 +67,7 @@ func (api *API) SyncWithPublishingCluster(req *http.Request) error {
 	// Restore the io.ReadCloser after reading from it
 	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-	bodyBytes, err = addPublicationToBody(bodyBytes)
+	bodyBytes, err = prepareAnnotationsBody(bodyBytes)
 	if err != nil {
 		return err
 	}
@@ -106,24 +116,25 @@ func (api *API) SyncWithPublishingCluster(req *http.Request) error {
 	return nil
 }
 
-func addPublicationToBody(bodyBytes []byte) ([]byte, error) {
-	// Decode the body into a map
-	var bodyMap map[string]interface{}
-	err := json.Unmarshal(bodyBytes, &bodyMap)
+func prepareAnnotationsBody(bodyBytes []byte) ([]byte, error) {
+	// Decode the body into an AnnotationsBody struct which matches the expected schema in publishing cluster
+	var ann AnnotationsBody
+	err := json.Unmarshal(bodyBytes, &ann)
 	if err != nil {
 		return nil, err
 	}
 
-	// Check if the map contains a key for "publication"
-	if _, ok := bodyMap["publication"]; !ok {
+	// Add publication so we pass the validation in publishing cluster
+	if ann.Publication == nil {
 		// If not, add it
-		bodyMap["publication"] = []string{FTPinkPublication}
-
-		// Re-encode the body into JSON
-		bodyBytes, err = json.Marshal(bodyMap)
-		if err != nil {
-			return nil, err
-		}
+		ann.Publication = []string{FTPinkPublication}
 	}
+
+	// Re-encode the body into JSON
+	bodyBytes, err = json.Marshal(ann)
+	if err != nil {
+		return nil, err
+	}
+
 	return bodyBytes, nil
 }


### PR DESCRIPTION

# Description

After the deployment of the annotations synchronization between PAC and Publishing cluster. We were sending PAC requests that does not validate with the annotation schemas in the publishing cluster causing errors.

## What

We are introducing an annotations body struct which helps us match the schema in the publishing cluster. This way we can filter the required fields and avoid validation errors.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-5624

## Anything, in particular, you'd like to highlight to reviewers

_Changes can be tested on Staging_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
